### PR TITLE
reverts from  media query test for safari

### DIFF
--- a/projects/bomb-game/style.css
+++ b/projects/bomb-game/style.css
@@ -316,7 +316,6 @@ button:focus {
 
   .game-container {
     width: 100vw;
-    background-color: bisque;
   }
 
   .bomb-image {


### PR DESCRIPTION
removes simple background color change for media query conditions. 

To do:
- Investigate why media query controlling orientation and sizing of the game may not be supported on safari.